### PR TITLE
Fixed bug when used "\\" at the end of string

### DIFF
--- a/lexer_reader.go
+++ b/lexer_reader.go
@@ -45,7 +45,7 @@ func (l *readerLexer) takeString() error {
 		return fmt.Errorf("Expected \" as start of string instead of %#U", cur)
 	}
 
-	var previous, byteBeforePrevious byte
+	var previous, byteBeforePrevious, secondByteBeforePrevious byte
 looper:
 	for {
 		curByte, err := l.bufInput.ReadByte()
@@ -55,17 +55,11 @@ looper:
 		l.lexeme.WriteByte(curByte)
 
 		if curByte == '"' {
-			if previous != '\\' || previous == '\\' && byteBeforePrevious == '\\' {
+			if previous != '\\' || previous == '\\' && byteBeforePrevious == '\\' && secondByteBeforePrevious != '\\' {
 				break looper
-			} else {
-				curByte, err = l.bufInput.ReadByte()
-				if err == io.EOF {
-					return errors.New("Unexpected EOF in string")
-				}
-				l.lexeme.WriteByte(curByte)
 			}
 		}
-
+		secondByteBeforePrevious = byteBeforePrevious
 		byteBeforePrevious = previous
 		previous = curByte
 	}

--- a/lexer_reader.go
+++ b/lexer_reader.go
@@ -45,7 +45,7 @@ func (l *readerLexer) takeString() error {
 		return fmt.Errorf("Expected \" as start of string instead of %#U", cur)
 	}
 
-	var previous byte
+	var previous, byteBeforePrevious byte
 looper:
 	for {
 		curByte, err := l.bufInput.ReadByte()
@@ -55,7 +55,7 @@ looper:
 		l.lexeme.WriteByte(curByte)
 
 		if curByte == '"' {
-			if previous != '\\' {
+			if previous != '\\' || previous == '\\' && byteBeforePrevious == '\\' {
 				break looper
 			} else {
 				curByte, err = l.bufInput.ReadByte()
@@ -66,6 +66,7 @@ looper:
 			}
 		}
 
+		byteBeforePrevious = previous
 		previous = curByte
 	}
 	return nil

--- a/lexer_reader.go
+++ b/lexer_reader.go
@@ -45,23 +45,21 @@ func (l *readerLexer) takeString() error {
 		return fmt.Errorf("Expected \" as start of string instead of %#U", cur)
 	}
 
-	var previous, byteBeforePrevious, secondByteBeforePrevious byte
-looper:
+	var backslashCount int
 	for {
 		curByte, err := l.bufInput.ReadByte()
 		if err == io.EOF {
 			return errors.New("Unexpected EOF in string")
 		}
 		l.lexeme.WriteByte(curByte)
-
-		if curByte == '"' {
-			if previous != '\\' || previous == '\\' && byteBeforePrevious == '\\' && secondByteBeforePrevious != '\\' {
-				break looper
-			}
+		if curByte == '"' && backslashCount % 2 == 0 {
+			break
 		}
-		secondByteBeforePrevious = byteBeforePrevious
-		byteBeforePrevious = previous
-		previous = curByte
+		if curByte == '\\' {
+            		backslashCount++
+        	} else {
+            		backslashCount = 0
+        	} 
 	}
 	return nil
 }


### PR DESCRIPTION
```
{
  "metrics": [
    {
        "path": "dpc\\root\\GRs\\PK\\gr047_mirror",
        "value": "0"
    },
    {
        "path": "dpc\\root\\GR\\PK\\",
        "value": "1"
    },
    {
        "path": "dpc\\root\\GRs\\PK\\gr048_mirror",
        "value": "1"
    }
  ]
}
```
The next command returns an error because backslash before quote.
```
$ ./jsonpath --file=test_export.json --path='$.metrics[*].path+' --keys
```
In this case backslash is escaped and there is no syntax error.
So we need to check the character before previous.